### PR TITLE
Display both DESeq2 & GSEA results

### DIFF
--- a/replica-client/src/components/analysis/AnalysisDetail.css
+++ b/replica-client/src/components/analysis/AnalysisDetail.css
@@ -6,14 +6,10 @@ table.result-table td {
     border: 1px solid white;
 }
 
-/* .analysis-info-flex {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-around;
-}
+.gsea-term-column {
+    max-width: 550px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 
-.result-info-flex {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-around;
-} */

--- a/replica-client/src/components/analysis/AnalysisDetail.jsx
+++ b/replica-client/src/components/analysis/AnalysisDetail.jsx
@@ -6,7 +6,7 @@ import './AnalysisDetail.css'
 export const AnalysisDetail = () => {
   const { analysisId } = useParams();
   const [analysis, setAnalysis] = useState(null);
-  const [resultData, setResultData] = useState([]);
+  const [resultData, setResultData] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [analysisTypes, setAnalysisTypes] = useState([]);
@@ -20,15 +20,23 @@ export const AnalysisDetail = () => {
         setAnalysis(data);
         setAnalysisTypes(analysisTypes);
         if (data.results[0] && data.results[0].result) {
-          // Clean and parse the JSON string
           const cleanedJsonString = data.results[0].result
-            .replace(/:\s*NaN/g, ': null')  // Replace NaN with null
-            .replace(/:\s*Infinity/g, ': null')  // Replace Infinity with null
-            .replace(/:\s*-Infinity/g, ': null');  // Replace -Infinity with null
+            .replace(/:\s*NaN/g, ': null')
+            .replace(/:\s*Infinity/g, ': null')
+            .replace(/:\s*-Infinity/g, ': null');
           
           try {
             const parsedResult = JSON.parse(cleanedJsonString);
-            setResultData(parsedResult.slice(0, 100)); // Get first 100 rows
+            if (data.analysis_type === 1) {
+              setResultData(parsedResult.slice(0, 100));
+            } else if (data.analysis_type === 2) {
+              setResultData({
+                significant_genes: parsedResult.significant_genes.slice(0, 100),
+                gsea_results: parsedResult.gsea_results.slice(0, 100)
+              });
+            } else {
+              setResultData(parsedResult);
+            }
           } catch (jsonError) {
             console.error("Error parsing JSON:", jsonError);
             setError('Error parsing result data');
@@ -45,15 +53,13 @@ export const AnalysisDetail = () => {
     fetchAnalysis();
   }, [analysisId]);
 
-
   const renderResultTable = () => {
-    if (resultData.length === 0) return null;
+    if (!resultData) return null;
 
-    const columns = Object.keys(resultData[0]);
-
-    return (
-      <div className="result-table-container" style={{overflowX: 'auto'}}>
-        {analysis.results[0].analysis_type <= 2 && (<table className="result-table">
+    if (analysis.analysis_type === 1) {
+      const columns = Object.keys(resultData[0]);
+      return (
+        <table className="result-table">
           <thead>
             <tr>
               {columns.map((column) => (
@@ -67,30 +73,84 @@ export const AnalysisDetail = () => {
                 {columns.map((column, colIndex) => (
                   <td 
                     key={`${index}-${column}`}
-                    style={
-                      // Adjust index for log2foldchange
-                      colIndex == 3
-                      ? { color: parseFloat(row[column]) >= 0 ? 'green' : 'red'}
-                      : {}
-                    }>{row[column]?.toString().substring(0, 15)}</td>
+                    style={colIndex === 3 ? { color: parseFloat(row[column]) >= 0 ? 'green' : 'red'} : {}}
+                  >
+                    {row[column]?.toString().substring(0, 15)}
+                  </td>
                 ))}
               </tr>
             ))}
           </tbody>
-        </table>)}
-        {analysis.results[0].analysis_type == 3 && (
-          resultData.map((result) => (
-            <div className="result-card" key={`${result?.file_name}`}>
-              <h3>{result?.sequence_id}</h3>
-              <img src={`/api/visualizations/${encodeURIComponent(result?.visualization_path)}`}
-               alt={`Contact map for ${result.file_name}`}/>
-            </div>
-          ))
-        )}
-      </div>
-    );
+        </table>
+      );
+    } else if (analysis.analysis_type === 2) {
+      return (
+        <>
+          <h4>Significant Genes</h4>
+          <table className="result-table">
+            <thead>
+              <tr>
+                {Object.keys(resultData.significant_genes[0]).map((column) => (
+                  <th key={column}>{column}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {resultData.significant_genes.map((row, index) => (
+                <tr key={index}>
+                  {Object.entries(row).map(([column, value], colIndex) => (
+                    <td 
+                      key={`${index}-${column}`}
+                      style={column === 'log2FoldChange' ? { color: parseFloat(value) >= 0 ? 'green' : 'red'} : {}}
+                    >
+                      {value?.toString().substring(0, 15)}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          <h4>GSEA Results</h4>
+          <table className="result-table">
+            <thead>
+              <tr>
+                {Object.keys(resultData.gsea_results[0]).map((column) => (
+                  <th key={column}>{column}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {resultData.gsea_results.map((row, index) => (
+                <tr key={index}>
+                  {Object.entries(row).map(([column, value], colIndex) => (
+                    <td key={`${index}-${column}`}
+                    className={colIndex === 0 ? 'gsea-term-column' : ''}>
+                      {colIndex === 0 
+                        ? value?.toString().substring(0, 70) 
+                        : value?.toString().substring(0, 15)}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </>
+      );
+    } else if (analysis.analysis_type === 3) {
+      return (
+        resultData.map((result) => (
+          <div className="result-card" key={`${result?.file_name}`}>
+            <h3>{result?.sequence_id}</h3>
+            <img 
+              src={`/api/visualizations/${encodeURIComponent(result?.visualization_path)}`}
+              alt={`Contact map for ${result.file_name}`}
+            />
+          </div>
+        ))
+      );
+    }
   };
-  
 
   if (loading) return <div>Loading...</div>;
   if (error) return <div>{error}</div>;
@@ -99,11 +159,10 @@ export const AnalysisDetail = () => {
   return (
     <div className="analysis-detail">
       <h2>Analysis Details</h2>
-
       <h3>Result ID: {analysis.results[0].id}</h3>
       <div className="result-info">
         <div className="result-info-flex">
-          <p><strong>Analysis Type:</strong> {analysisTypes[analysis.results[0].analysis_type-1].description}</p>
+          <p><strong>Analysis Type:</strong> {analysisTypes[analysis.results[0].analysis_type-1]?.description}</p>
           <p><strong>Status:</strong> {analysis.status}</p>
           <p><strong>GSEA Library:</strong> {analysis.gsea_library ? analysis.gsea_library : "N/A"}</p>
         </div>
@@ -112,8 +171,10 @@ export const AnalysisDetail = () => {
         <p><strong>Updated:</strong> {(new Date(analysis.updated_at)).toLocaleString()}</p>
       </div>
 
-      <h3>Result Data (Truncated)</h3>
-      {renderResultTable()}
+      <h3>Result Data (Top 100 Rows)</h3>
+      <div className="result-table-container" style={{overflowX: 'auto'}}>
+        {renderResultTable()}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
This PR adds the display of multiple result tables for DESeq2/GSEA analysis results on the AnalysisDetail component

Changes:
Formats analysis result for DESeq2/GSEA analysis as a dict containing significant_genes and gsea_results
AnalysisDetail parses and truncates both result objects
AnalysisDetail component now conditionally renders results by analysis_type
GSEA results are now rendered in a styled table below significant genes for DESeq2/GSEA analysis results
